### PR TITLE
check for `unencodedParameters` != nil added. When you are passing an…

### DIFF
--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -270,7 +270,7 @@ static NSString* timestamp() {
     if ([method isEqualToString:@"GET"] || [method isEqualToString:@"DELETE"] || [method isEqualToString:@"HEAD"])
     {
         id path = [oauth setParameters:unencodedParameters];
-        if (path) {
+        if (path && unencodedParameters) {
             [path insertString:@"?" atIndex:0];
             [path insertString:encodedPathWithoutQuery atIndex:0];
         } else {


### PR DESCRIPTION
… empty [:], you expect this check to be evaluated to `false`. The result is removing unnecessary "?" added at the end of the query string.