### PR TITLE
Restore ^ to escaped characters

### DIFF
--- a/TDOAuth.m
+++ b/TDOAuth.m
@@ -34,7 +34,7 @@
 #import <OMGHTTPURLRQ/OMGUserAgent.h>
 
 #define TDPCEN(s) \
-      ([[s description] stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@"!*'();:@&=+$,/?%#[] "] invertedSet]])
+      ([[s description] stringByAddingPercentEncodingWithAllowedCharacters:[[NSCharacterSet characterSetWithCharactersInString:@"^!*'();:@&=+$,/?%#[] "] invertedSet]])
 
 #define TDChomp(s) { \
     const NSUInteger length = [s length]; \


### PR DESCRIPTION
The deprecated method (replaced in commit 63444d487cbb7a6c05dd2be3bda31b09b9160a08) was escaping the ^ character.